### PR TITLE
Fix documentation URL (kairn.dev → GitHub README)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ kairn = "kairn.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/kairn-ai/kairn"
-Documentation = "https://kairn.dev"
+Documentation = "https://github.com/kairn-ai/kairn#readme"
 Repository = "https://github.com/kairn-ai/kairn"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

- Points the documentation URL in `pyproject.toml` to the GitHub README instead of the non-existent `kairn.dev` domain

Fixes #1