### PR TITLE
fix(memory): FTS query shaping for kn_memories + publish LongMemEval (56.2%)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,88 @@
+# Kairn Benchmarks
+
+Memory systems are easy to describe and hard to measure. This page reports
+Kairn's recall quality on a published, third-party benchmark so the "context
+aware" claim is a number, not an adjective.
+
+## LongMemEval
+
+[LongMemEval](https://github.com/xiaowu0162/LongMemEval) is a 500-question
+benchmark for long-term conversational memory. Each question ships with a long
+multi-session chat "haystack"; a system must ingest it, recall the relevant
+turns, answer, and a judge scores the answer against gold.
+
+**Result: 56.2% overall on LongMemEval-S (500 questions).**
+
+| Run | Date | Reader | Judge | Sample | Score |
+|-----|------|--------|-------|--------|-------|
+| `full-500-s` | 2026-06-12 | GPT-4o | GPT-4o | 500 / 500 | **0.562** |
+
+500 of 500 questions scored, 0 errors. Mean recall latency: **1.4 ms** per
+query (FTS5, in-process, no network).
+
+### Per-category breakdown
+
+The headline number hides where the work is. Kairn is strong on single-session
+recall and abstention, and weak on cross-session synthesis, temporal reasoning
+and one-shot preferences. This is the roadmap, in data:
+
+| Category | n | Accuracy |
+|----------|----|----------|
+| single-session-user | 70 | 91.4% |
+| single-session-assistant | 56 | 83.9% |
+| knowledge-update | 78 | 70.5% |
+| temporal-reasoning | 133 | 42.9% |
+| multi-session | 133 | 41.4% |
+| single-session-preference | 30 | 10.0% |
+| abstention | 30 | 96.7% |
+
+Read it as: Kairn reliably finds a fact stated once in a session (91%) and
+reliably declines to answer when the fact was never stated (97%). It loses
+ground when an answer must be assembled across many sessions or resolved on a
+timeline. Those weak categories are the largest, so they set the ceiling, and
+they are where the next architectural work goes (entity-centric linking and
+bi-temporal validity).
+
+## How it compares
+
+LongMemEval is run by several memory products. Treat cross-vendor numbers as
+directional, not a controlled head-to-head: readers, ingestion and judge
+prompts differ between published runs.
+
+| System | LongMemEval-S | Source |
+|--------|---------------|--------|
+| Zep / Graphiti | 63.8% | vendor-published |
+| **Kairn** | **56.2%** | this repo, protocol below |
+| mem0 | 49.0% | vendor-published |
+
+## Protocol and honesty notes
+
+- **Reader + judge:** GPT-4o for both, matching the published LongMemEval
+  protocol (binary judge of hypothesis vs gold).
+- **Recall path:** the live `kn_memories` path - free text is shaped into an
+  FTS5 keyword query (`core.fts.to_fts_query`), matched with BM25 ranking, and
+  re-ordered with decay as a coarse tiebreak.
+- **Determinism:** fixed sample seed (42), greedy decoding where the API allows.
+- **Conservative lower bound:** each ingested turn-pair is truncated to ~1800
+  characters before storage, so long turns lose tail context. Real scores with
+  full-length ingestion would be equal or higher.
+- **Single run:** one full pass, not an average of several. No cherry-picking
+  across runs.
+- **Sandbox:** every question runs against a fresh, throwaway SQLite database;
+  no production workspace is read or written during a run.
+
+## Reproducing
+
+The harness lives in the [Evolving](https://github.com/primeline-ai) research
+tree and drives Kairn's public library directly (`ExperienceEngine.search`,
+the same call `kn_memories` makes). To reproduce:
+
+1. Download the LongMemEval-S dataset from the upstream repo.
+2. For each question: ingest the haystack sessions as experiences, recall the
+   top-k with `ExperienceEngine.search(text=...)`, answer with a reader LLM
+   from the recalled excerpts, and judge the answer against gold.
+3. Keep the sandbox contract: one fresh DB per question, production workspace
+   untouched (verify by hashing the DB file before and after).
+
+Latency-only benchmarks (insert/query throughput at scale) are available via
+`kairn benchmark <workspace>`.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ relevance(t) = initial_score × e^(-decay_rate × days)
 - Auto-promotion: 5+ accesses → permanent node
 - Node access tracking: `kn_recall`, `kn_context`, and `kn_crossref` log which nodes were accessed, feeding the decay and promotion pipeline
 
+## Benchmarks
+
+Kairn scores **56.2% overall on LongMemEval-S** (500 questions, GPT-4o reader
++ judge), with a published per-category breakdown and reproduction protocol in
+[BENCHMARKS.md](BENCHMARKS.md). Recall latency is ~1.4 ms per query.
+
 ## CLI
 
 ```bash
@@ -206,7 +212,7 @@ ruff check src/ && ruff format src/
 
 ```
 src/kairn/
-├── server.py              # FastMCP server + 18 tools
+├── server.py              # FastMCP server + 21 tools
 ├── cli.py                 # CLI commands
 ├── config.py              # Configuration
 ├── core/

--- a/src/kairn/core/experience.py
+++ b/src/kairn/core/experience.py
@@ -10,6 +10,7 @@ import math
 from datetime import UTC, datetime
 from typing import Any
 
+from kairn.core.fts import to_fts_query
 from kairn.events.bus import EventBus
 from kairn.events.types import EventType
 from kairn.models.experience import VALID_CONFIDENCES, VALID_TYPES, Experience
@@ -191,9 +192,26 @@ class ExperienceEngine:
             strength is the primary order and decay-relevance acts as a
             coarse tiebreak; without text, sorted by relevance descending.
         """
+        # Shape free-text into a safe FTS5 query (quoted OR of keywords). This
+        # is the same helper the intelligence layer (kn_recall/kn_context) and
+        # the LongMemEval benchmark use, so kn_memories now runs the identical,
+        # crash-proof recall path. Raw text would let bare hyphens / reserved
+        # words reach MATCH and raise OperationalError ("no such column: ...").
+        # If the query has no searchable keyword, there is nothing to match.
+        # Re-shaping an already-shaped query is idempotent (quotes/OR are
+        # stripped by the tokenizer and the surviving keywords re-quote to the
+        # same string), so callers that pre-shape stay correct.
+        fts_text: str | None
+        if text is not None:
+            fts_text = to_fts_query(text)
+            if fts_text is None:
+                return []
+        else:
+            fts_text = None
+
         # Query from store (the FTS path returns rows in BM25 match order)
         results = await self.store.query_experiences(
-            text=text,
+            text=fts_text,
             exp_type=exp_type,
             limit=100000,  # Get all first, filter by relevance
             offset=0,
@@ -210,7 +228,7 @@ class ExperienceEngine:
             if current_relevance >= min_relevance:
                 scored.append((exp, current_relevance))
 
-        if text:
+        if fts_text is not None:
             # Match strength stays primary: quantize relevance into coarse
             # buckets and stable-sort by bucket, so the store's BM25 order
             # survives within each bucket. Sorting by exact relevance would

--- a/src/kairn/core/fts.py
+++ b/src/kairn/core/fts.py
@@ -1,0 +1,112 @@
+"""FTS5 query shaping shared across the intelligence and experience layers.
+
+Natural-language queries cannot be handed to SQLite FTS5 `MATCH` verbatim:
+bare hyphens, colons and reserved words (`AND`/`OR`/`NOT`/`NEAR`) are parsed
+as query operators and raise `sqlite3.OperationalError` (e.g. the query
+"self-healing" is read as a column filter and fails with "no such column:
+healing"). `to_fts_query` lowercases, tokenizes to safe alphanumerics, drops
+stop-words and reserved tokens, then quotes each surviving term and joins with
+OR so any keyword can match. The result is always a valid FTS5 string literal
+sequence, or None when nothing searchable remains.
+
+This module has no internal kairn dependencies so both `core.intelligence`
+(which imports `core.experience`) and `core.experience` can import it without
+creating an import cycle.
+"""
+
+from __future__ import annotations
+
+import re
+
+_STOP_WORDS = {
+    "the",
+    "a",
+    "an",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "will",
+    "would",
+    "could",
+    "should",
+    "may",
+    "might",
+    "can",
+    "shall",
+    "to",
+    "of",
+    "in",
+    "for",
+    "on",
+    "with",
+    "at",
+    "by",
+    "from",
+    "as",
+    "into",
+    "about",
+    "and",
+    "or",
+    "but",
+    "not",
+    "no",
+    "so",
+    "yet",
+    "i",
+    "me",
+    "we",
+    "us",
+    "you",
+    "he",
+    "she",
+    "it",
+    "they",
+    "them",
+    "my",
+    "your",
+    "his",
+    "her",
+    "its",
+    "our",
+    "their",
+    "this",
+    "that",
+    "these",
+    "those",
+    "need",
+    "want",
+    "try",
+}
+
+_FTS_RESERVED = {"and", "or", "not", "near"}
+
+
+def to_fts_query(text: str) -> str | None:
+    """Convert natural language to a safe FTS5 OR query.
+
+    Returns a quoted OR-joined keyword string (always valid FTS5), or None
+    when no searchable keyword survives stop-word/length filtering.
+    """
+    words = re.findall(r"[a-zA-Z0-9_]+", text.lower())
+    keywords = [
+        w for w in words if w not in _STOP_WORDS and w not in _FTS_RESERVED and len(w) > 2
+    ]
+    if not keywords:
+        return None
+    return " OR ".join(f'"{w}"' for w in keywords)
+
+
+# Backward-compatible private alias. Historical callers (and the LongMemEval
+# benchmark harness) import the underscore name from core.intelligence; that
+# re-export now resolves here.
+_to_fts_query = to_fts_query

--- a/src/kairn/core/intelligence.py
+++ b/src/kairn/core/intelligence.py
@@ -6,13 +6,13 @@ Bridges graph, experience, and router engines into unified knowledge operations.
 from __future__ import annotations
 
 import logging
-import re
 import sqlite3
 import uuid
 from datetime import UTC, datetime
 from typing import Any
 
 from kairn.core.experience import ExperienceEngine
+from kairn.core.fts import _to_fts_query  # used here + re-exported for back-compat
 from kairn.core.graph import GraphEngine
 from kairn.core.ideas import IdeaEngine
 from kairn.core.memory import ProjectMemory
@@ -24,85 +24,9 @@ from kairn.storage.base import StorageBackend
 
 logger = logging.getLogger(__name__)
 
-_STOP_WORDS = {
-    "the",
-    "a",
-    "an",
-    "is",
-    "are",
-    "was",
-    "were",
-    "be",
-    "been",
-    "being",
-    "have",
-    "has",
-    "had",
-    "do",
-    "does",
-    "did",
-    "will",
-    "would",
-    "could",
-    "should",
-    "may",
-    "might",
-    "can",
-    "shall",
-    "to",
-    "of",
-    "in",
-    "for",
-    "on",
-    "with",
-    "at",
-    "by",
-    "from",
-    "as",
-    "into",
-    "about",
-    "and",
-    "or",
-    "but",
-    "not",
-    "no",
-    "so",
-    "yet",
-    "i",
-    "me",
-    "we",
-    "us",
-    "you",
-    "he",
-    "she",
-    "it",
-    "they",
-    "them",
-    "my",
-    "your",
-    "his",
-    "her",
-    "its",
-    "our",
-    "their",
-    "this",
-    "that",
-    "these",
-    "those",
-    "need",
-    "want",
-    "try",
-}
-
-
-def _to_fts_query(text: str) -> str | None:
-    """Convert natural language to FTS5 OR query with proper escaping."""
-    words = re.findall(r"[a-zA-Z0-9_]+", text.lower())
-    fts_reserved = {"and", "or", "not", "near"}
-    keywords = [w for w in words if w not in _STOP_WORDS and w not in fts_reserved and len(w) > 2]
-    if not keywords:
-        return None
-    return " OR ".join(f'"{w}"' for w in keywords)
+# FTS5 query shaping (_to_fts_query, _STOP_WORDS) now lives in core.fts and is
+# re-exported via the top-of-module import so the experience path can share it
+# without an import cycle. See core/fts.py.
 
 
 # Max candidates returned by kn_learn FTS5 scan. Set conservatively;

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1161,3 +1161,53 @@ class TestPromotePending:
         # The "should-be-rolled-back" node must NOT exist.
         rolled = await store.get_node("should-be-rolled-back")
         assert rolled is None
+
+
+# ---------------------------------------------------------------------------
+# FTS query shaping (kn_memories crash-proofing + benchmark-path alignment).
+# Regression for the live gotcha: hyphenated / reserved-word queries reached
+# SQLite FTS5 MATCH verbatim and raised OperationalError ("no such column:
+# <suffix>"). search() now routes free text through core.fts.to_fts_query,
+# the same helper the intelligence layer and the LongMemEval harness use.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_hyphenated_query_does_not_crash(engine):
+    """A hyphenated term must not raise and must still find the match."""
+    await engine.save(
+        type="gotcha",
+        content="system weakness gap audit drift self-healing loop",
+        confidence="high",
+    )
+    results = await engine.search(text="self-healing", limit=5)
+    assert len(results) == 1
+    assert "self-healing" in results[0].content
+
+
+@pytest.mark.asyncio
+async def test_search_reserved_word_query_does_not_crash(engine):
+    """A bare FTS5 reserved word (AND/OR/NOT/NEAR) must not raise."""
+    await engine.save(type="solution", content="plain content here", confidence="high")
+    # "AND" alone yields no searchable keyword -> empty, never an exception.
+    assert await engine.search(text="AND", limit=5) == []
+    assert await engine.search(text="a OR b", limit=5) == []
+
+
+@pytest.mark.asyncio
+async def test_search_multi_term_uses_or_semantics(engine):
+    """Multi-term queries match ANY keyword (OR), aligning kn_memories with
+    its sibling tools and the benchmarked recall path."""
+    await engine.save(type="pattern", content="alpha tooling notes", confidence="high")
+    await engine.save(type="pattern", content="beta tooling notes", confidence="high")
+    results = await engine.search(text="alpha beta", limit=10)
+    contents = {r.content for r in results}
+    assert "alpha tooling notes" in contents
+    assert "beta tooling notes" in contents
+
+
+@pytest.mark.asyncio
+async def test_search_all_stopwords_returns_empty(engine):
+    """A query with no searchable keyword returns [] rather than matching all."""
+    await engine.save(type="solution", content="real durable content", confidence="high")
+    assert await engine.search(text="the a is of", limit=5) == []


### PR DESCRIPTION
## What

Two things, one diff:

1. **Fix the `kn_memories` FTS crash + align it with the benchmarked recall path.** Raw user text reached SQLite FTS5 `MATCH` verbatim, so hyphenated or reserved-word queries (e.g. `self-healing`) raised `OperationalError: no such column: healing`. The intelligence layer (`kn_recall`/`kn_context`) already sanitized via `_to_fts_query`, but the experience path did not - so the two diverged, and the LongMemEval benchmark was measured on the sanitized path while production `kn_memories` ran the raw one.

2. **Publish the first real recall-quality benchmark.** `BENCHMARKS.md`: 56.2% on LongMemEval-S with a per-category breakdown, honest caveats, and a reproduction protocol.

## Changes

- New neutral `core/fts.py` holding `to_fts_query` + `_STOP_WORDS` (no internal kairn deps, avoids an import cycle since `core.intelligence` imports `core.experience`). Re-exported from `core.intelligence` for back-compat.
- `ExperienceEngine.search` now shapes free text through `to_fts_query` before the store query; empty / all-stopword queries return `[]` instead of raising. This fixes the crash **and** makes `kn_memories` run the same OR-semantics path the 56.2% was measured on.
- 4 regression tests (hyphen, reserved word, OR semantics, stopword-empty).
- `BENCHMARKS.md` + README Benchmarks section; README "18 tools" -> "21 tools" fix.

## Verification

- Full suite: **460 passed, 0 failures**.
- Live repro before: `search(text="self-healing")` -> `OperationalError`. After: returns the matching experience; bare `AND` -> `[]` (no crash).
- Pre-merge code review (sonnet/high) applied: hardened the sort-branch guard to key on `fts_text` not `text`.

## Deliberate behavior change

Multi-term `kn_memories` text now uses **OR** semantics (any keyword), matching the sibling tools and the benchmark, where the raw path previously used FTS5's default AND. Broader recall is the right default for a memory tool.

## Deferred

`core.intelligence` still pre-shapes text before calling `search()`, which now re-shapes it. The double pass is idempotent for real queries, but the None-boundary differs for degenerate all-stopword inputs, so collapsing it needs its own test. Left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)